### PR TITLE
Reject pre‑Amiga‑epoch timestamps with clear error messages

### DIFF
--- a/adate.c
+++ b/adate.c
@@ -319,7 +319,14 @@ BOOL convert_unix_to_timeval(const char *epoch, struct TimeVal *tv) {
         raw_seconds = atoll(epoch) - 252460800LL;
     }
 
-    if (raw_seconds < 0) raw_seconds = 0;
+    if (raw_seconds < 0) {
+        if (epoch[0] == '@') {
+            printf("Error: Amiga epoch seconds cannot be negative: %s\n", epoch);
+        } else {
+            printf("Error: Unix epoch %s is before the Amiga epoch (1978-01-01 00:00:00 UTC).\n", epoch);
+        }
+        return FALSE;
+    }
     if (raw_seconds > 4294967295LL) raw_seconds = 4294967295LL;
 
     tv->tv_secs = (ULONG)raw_seconds;
@@ -420,10 +427,13 @@ BOOL parse_date_string(const char *datestr, int *year, int *month, int *day, int
         long long unix_seconds = atoll(datestr + 1); // Parse the value after '@'
         long long amiga_seconds = unix_seconds - 252460800; // Adjust for Unix to Amiga epoch
 
-        // Clamp to valid Amiga range
+        // Reject pre-Amiga-epoch timestamps instead of silently clamping to 1978.
         if (amiga_seconds < 0) {
-            amiga_seconds = 0; // Set to the start of Amiga epoch
-        } else if (amiga_seconds > 4294967295LL) {
+            printf("Error: Unix epoch %lld is before the Amiga epoch (1978-01-01 00:00:00 UTC).\n", unix_seconds);
+            return FALSE;
+        }
+
+        if (amiga_seconds > 4294967295LL) {
             amiga_seconds = 4294967295LL; // Clamp to max 32-bit value
         }
 


### PR DESCRIPTION
### Motivation
- The tool silently clamped timestamps that mapped before the Amiga epoch (1978-01-01) to 1978, which produced misleading output for pre‑epoch Unix values and negative Amiga‑epoch inputs.
- The change aims to surface out‑of‑range inputs with explicit errors rather than silently coercing them into the representable range.

### Description
- `convert_unix_to_timeval()` now returns `FALSE` and prints a clear error when a converted timestamp is negative, distinguishing negative `@` (Amiga‑epoch) inputs from plain Unix epoch inputs.
- The `@<epoch>` branch in `parse_date_string()` was updated to fail fast with an explicit pre‑epoch error instead of forcing the date to 1978‑01‑01.
- Upper bound behavior remains unchanged: values above the 32‑bit Amiga limit are still clamped to `4294967295`.
- No other formatting or date‑calculation logic was altered. The changes are localized to epoch conversion and `@` parsing paths.

### Testing
- Performed code inspections using `rg`/`sed`/`nl` to verify modified sections and confirmed the diffs are as intended (succeeded).
- Committed the change (`git add` / `git commit`) and generated the PR metadata successfully (succeeded).
- No compile or runtime unit tests were executed in this rollout, so behavior was not validated by automated build/test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a120d506b34832dafb78bbe48eb3e12)