### PR TITLE
Fix week-number (%U/%W) logic and suppress misleading ISO error during RFC2822 parse

### DIFF
--- a/adate.c
+++ b/adate.c
@@ -390,12 +390,15 @@ int calculate_week_number(int year, int month, int day, int week_start) {
 
     if (week_start == 0) {
         /* %U: week starts Sunday; days before first Sunday are week 00. */
-        return (day_of_year + 7 - jan1_weekday) / 7;
+        int first_sunday_offset = (7 - jan1_weekday) % 7;
+        if (day_of_year < first_sunday_offset) return 0;
+        return 1 + ((day_of_year - first_sunday_offset) / 7);
     }
 
     /* %W: week starts Monday; days before first Monday are week 00. */
-    int jan1_monday_index = (jan1_weekday == 0) ? 6 : (jan1_weekday - 1);
-    return (day_of_year + 7 - jan1_monday_index) / 7;
+    int first_monday_offset = (8 - jan1_weekday) % 7;
+    if (day_of_year < first_monday_offset) return 0;
+    return 1 + ((day_of_year - first_monday_offset) / 7);
 }
 
 
@@ -482,7 +485,6 @@ BOOL parse_date_string(const char *datestr, int *year, int *month, int *day, int
             tv->tv_micro = 0;
             return TRUE;
         }
-        printf("Error: Invalid ISO 8601 date: %s\n", datestr);
     }
 
     // Check for YYYY-MM-DD


### PR DESCRIPTION
### Motivation
- Fix an off-by-one in `%U` (Sunday-start) week numbers (e.g., `2024-12-10` returned `50` but should be `49`) and make `%W` (Monday-start) consistent with `strftime` semantics. 
- Prevent a misleading `Invalid ISO 8601 date` message from being printed while parsing non-ISO inputs such as RFC 2822 strings.

### Description
- Update `calculate_week_number` in `adate.c` to compute `first_sunday_offset` and `first_monday_offset`, return `00` for days before the first week boundary, and otherwise compute weeks starting at `01` to match `strftime` semantics. 
- Remove the premature error print from the ISO-8601 `'T'` branch in `parse_date_string` so later parsing paths (e.g., RFC 2822) can succeed without producing spurious error output. 
- Changes are localized to `adate.c` and are minimal and self-contained.

### Testing
- Ran source inspections using `nl`/`sed` to verify the updated logic ranges and confirm the removal of the premature ISO error print, and those checks succeeded. 
- Invoked the repository PR recording tool to produce the PR metadata for review; the tool run succeeded. 
- No unit test harness is present in the repository, so no automated unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a120fb590b8832db64dbf49e1a7c453)